### PR TITLE
Optional CutOut Position for Material Finder

### DIFF
--- a/fast_barcode_scanner/lib/src/overlays/material_finder_overlay/material_finder_overlay.dart
+++ b/fast_barcode_scanner/lib/src/overlays/material_finder_overlay/material_finder_overlay.dart
@@ -34,23 +34,23 @@ class MaterialPreviewOverlay extends StatefulWidget {
   final Color sensingColor;
   final CutOutShape cutOutShape;
   final Color cutOutBorderColor;
-  
+
   /// Width of the cutOut
-  /// 
-  /// 
+  ///
+  ///
   final double? cutOutWidth;
 
   /// Height of the cutOut
-  /// 
+  ///
   /// If [cutOutShape] is [CutOutShape.square] then [cutOutHeight]
   /// won't be applied, instead [cutOutWidth] will be used as [cutOutHeight]
   final double? cutOutHeight;
 
   /// Offset for the center of the cutOut
-  /// 
+  ///
   /// Cannot be at the origin and end of the screen
-  /// 
-  /// 
+  ///
+  ///
   final Offset? cutOutCenter;
 
   @override
@@ -152,6 +152,9 @@ class MaterialPreviewOverlayState extends State<MaterialPreviewOverlay>
                     borderPaint: sensingBorderPaint,
                     backgroundColor: widget.backgroundColor,
                     cutOutShape: widget.cutOutShape,
+                    cutOutWidth: widget.cutOutWidth,
+                    cutOutHeight: widget.cutOutHeight,
+                    cutOutCenter: widget.cutOutCenter,
                   ),
                 ),
               )

--- a/fast_barcode_scanner/lib/src/overlays/material_finder_overlay/material_finder_overlay.dart
+++ b/fast_barcode_scanner/lib/src/overlays/material_finder_overlay/material_finder_overlay.dart
@@ -24,6 +24,9 @@ class MaterialPreviewOverlay extends StatefulWidget {
     this.backgroundColor = Colors.black38,
     this.cutOutShape = CutOutShape.wide,
     this.cutOutBorderColor = Colors.black87,
+    this.cutOutWidth,
+    this.cutOutHeight,
+    this.cutOutCenter,
   }) : super(key: key);
 
   final bool showSensing;
@@ -31,6 +34,24 @@ class MaterialPreviewOverlay extends StatefulWidget {
   final Color sensingColor;
   final CutOutShape cutOutShape;
   final Color cutOutBorderColor;
+  
+  /// Width of the cutOut
+  /// 
+  /// 
+  final double? cutOutWidth;
+
+  /// Height of the cutOut
+  /// 
+  /// If [cutOutShape] is [CutOutShape.square] then [cutOutHeight]
+  /// won't be applied, instead [cutOutWidth] will be used as [cutOutHeight]
+  final double? cutOutHeight;
+
+  /// Offset for the center of the cutOut
+  /// 
+  /// Cannot be at the origin and end of the screen
+  /// 
+  /// 
+  final Offset? cutOutCenter;
 
   @override
   MaterialPreviewOverlayState createState() => MaterialPreviewOverlayState();
@@ -114,6 +135,9 @@ class MaterialPreviewOverlayState extends State<MaterialPreviewOverlay>
                 borderPaint: defaultBorderPaint,
                 backgroundColor: widget.backgroundColor,
                 cutOutShape: widget.cutOutShape,
+                cutOutWidth: widget.cutOutWidth,
+                cutOutHeight: widget.cutOutHeight,
+                cutOutCenter: widget.cutOutCenter,
               ),
             ),
             if (widget.showSensing)

--- a/fast_barcode_scanner/lib/src/overlays/material_finder_overlay/material_finder_painter.dart
+++ b/fast_barcode_scanner/lib/src/overlays/material_finder_overlay/material_finder_painter.dart
@@ -32,20 +32,22 @@ class MaterialFinderPainter extends CustomPainter {
 
     final screenRect = Rect.fromLTWH(0, 0, size.width, size.height);
 
-    final cutOutWidth = screenRect.width - 45;
+    final width = cutOutWidth ?? screenRect.width * 0.5;
 
-    double cutOutHeight;
+    final center = cutOutCenter ?? screenRect.center;
+
+    double height;
     if (cutOutShape == CutOutShape.square) {
-      cutOutHeight = cutOutWidth;
+      height = width;
     } else {
-      cutOutHeight = 1 / (16 / 9) * cutOutWidth;
+      height = cutOutHeight ?? 1 / (16 / 9) * width;
     }
 
     final cutOut = RRect.fromRectXY(
       Rect.fromCenter(
-        center: screenRect.center,
-        width: cutOutWidth,
-        height: cutOutHeight,
+        center: center,
+        width: width,
+        height: height,
       ),
       12,
       12,

--- a/fast_barcode_scanner/lib/src/overlays/material_finder_overlay/material_finder_painter.dart
+++ b/fast_barcode_scanner/lib/src/overlays/material_finder_overlay/material_finder_painter.dart
@@ -63,7 +63,7 @@ class MaterialFinderPainter extends CustomPainter {
 
     final screenRect = Rect.fromLTWH(0, 0, size.width, size.height);
 
-    final width = cutOutWidth ?? screenRect.width * 0.5;
+    final width = cutOutWidth ?? screenRect.width * 0.8;
 
     final center = cutOutCenter ?? screenRect.center;
 

--- a/fast_barcode_scanner/lib/src/overlays/material_finder_overlay/material_finder_painter.dart
+++ b/fast_barcode_scanner/lib/src/overlays/material_finder_overlay/material_finder_painter.dart
@@ -10,6 +10,9 @@ class MaterialFinderPainter extends CustomPainter {
     required this.borderPaint,
     required this.backgroundColor,
     required this.cutOutShape,
+    this.cutOutWidth,
+    this.cutOutHeight,
+    this.cutOutCenter,
   });
 
   final double inflate;
@@ -19,6 +22,9 @@ class MaterialFinderPainter extends CustomPainter {
   final Paint borderPaint;
   final Color backgroundColor;
   final CutOutShape cutOutShape;
+  final double? cutOutWidth;
+  final double? cutOutHeight;
+  final Offset? cutOutCenter;
 
   @override
   void paint(Canvas canvas, Size size) {

--- a/fast_barcode_scanner/lib/src/overlays/material_finder_overlay/material_finder_painter.dart
+++ b/fast_barcode_scanner/lib/src/overlays/material_finder_overlay/material_finder_painter.dart
@@ -28,6 +28,37 @@ class MaterialFinderPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
+    if (cutOutCenter != null) {
+      assert(cutOutCenter != const Offset(0.0, 0.0),
+          "CutOutCenter can't be at the origin");
+          assert(cutOutCenter != Offset(size.width, 0.0),
+          "CutOutCenter can't be at TopRight");
+          assert(cutOutCenter != Offset(size.width, size.height),
+          "CutOutCenter can't be at BottomRight");
+          assert(cutOutCenter != Offset(0.0, size.height),
+          "CutOutCenter can't be at the BottomLeft");
+    }
+    if (cutOutWidth != null) {
+      assert(cutOutWidth! <= size.width,
+          "CutOutWidth $cutOutWidth can't be greater than Screen Width ${size.width}");
+      if (cutOutCenter != null) {
+        assert(cutOutCenter!.dx - (cutOutWidth! / 2) >= 0.0,
+            "CutOut is overflowing towards left by ${(cutOutCenter!.dx - (cutOutWidth! / 2)).abs()} by pixels, adjust CutOutWidth");
+        assert(cutOutCenter!.dx + (cutOutWidth! / 2) <= size.width,
+            "CutOut is overflowing towards right by ${(cutOutCenter!.dx - (cutOutWidth! / 2)).abs()} pixels, adjust it's CutOutWidth");
+      }
+    }
+    if (cutOutHeight != null && cutOutShape == CutOutShape.wide) {
+      assert(cutOutHeight! <= size.height,
+          "CutOutHeigth $cutOutHeight can't be greater than Screen Height ${size.height}");
+      if (cutOutCenter != null) {
+        assert(cutOutCenter!.dy - (cutOutHeight! / 2) >= 0.0,
+            "CutOut is overflowing towards top by ${(cutOutCenter!.dy - (cutOutHeight! / 2)).abs()} pixels, adjust it's CutOutHeight");
+        assert(cutOutCenter!.dy + (cutOutHeight! / 2) <= size.height,
+            "CutOut is overflowing towards bottom by ${(cutOutCenter!.dy - (cutOutHeight! / 2)).abs()} pixels, adjust it's CutOutHeight");
+      }
+    }
+
     final backgroundPaint = Paint()..color = backgroundColor;
 
     final screenRect = Rect.fromLTWH(0, 0, size.width, size.height);


### PR DESCRIPTION
Hey liked the performance of the plugin.

Have added optional param to set CutOut Center, Height and Width.

This would help in positioning the CutOut any where on the screen and size the cutout with any width and height

Also, I have added assertions so that the CutOut won't overflow to the sides.

Hope this gets merged