### PR TITLE
#61 analysis size

### DIFF
--- a/fast_barcode_scanner/android/src/main/kotlin/com/jhoogstraat/fast_barcode_scanner/Camera.kt
+++ b/fast_barcode_scanner/android/src/main/kotlin/com/jhoogstraat/fast_barcode_scanner/Camera.kt
@@ -173,6 +173,7 @@ class Camera(
 
         imageAnalysis = ImageAnalysis.Builder()
             .setTargetRotation(Surface.ROTATION_0)
+            .setTargetResolution(scannerConfiguration.resolution.portrait())
             .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
             .build()
             .also { it.setAnalyzer(cameraExecutor, barcodeScanner) }

--- a/fast_barcode_scanner/pubspec.yaml
+++ b/fast_barcode_scanner/pubspec.yaml
@@ -14,10 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   fast_barcode_scanner_platform_interface:
-    git:
-      url: https://github.com/jhoogstraat/fast_barcode_scanner
-      ref: develop
-      path: fast_barcode_scanner_platform_interface
+    path: ../fast_barcode_scanner_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/fast_barcode_scanner/pubspec.yaml
+++ b/fast_barcode_scanner/pubspec.yaml
@@ -1,6 +1,8 @@
 name: fast_barcode_scanner
 description: A fast barcode scanner using MLKit on Android and AVFoundation on iOS.
 version: 2.0.0-dev.5
+#remove this before we publish
+publish_to: none
 homepage: https://github.com/jhoogstraat/fast_barcode_scanner
 repository: https://github.com/jhoogstraat/fast_barcode_scanner
 
@@ -11,7 +13,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  fast_barcode_scanner_platform_interface: 2.0.0-dev.2
+  fast_barcode_scanner_platform_interface:
+    git:
+      url: https://github.com/jhoogstraat/fast_barcode_scanner
+      ref: develop
+      path: fast_barcode_scanner_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/fast_barcode_scanner/pubspec.yaml
+++ b/fast_barcode_scanner/pubspec.yaml
@@ -1,8 +1,7 @@
 name: fast_barcode_scanner
 description: A fast barcode scanner using MLKit on Android and AVFoundation on iOS.
-version: 2.0.0-dev.2
+version: 2.0.0-dev.5
 homepage: https://github.com/jhoogstraat/fast_barcode_scanner
-publish_to: none
 repository: https://github.com/jhoogstraat/fast_barcode_scanner
 
 environment:
@@ -12,8 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  fast_barcode_scanner_platform_interface:
-    path: ../fast_barcode_scanner_platform_interface
+  fast_barcode_scanner_platform_interface: 2.0.0-dev.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
#61 pdf417 not read consistently

On Android, the analysis and preview resolution config is different causing issues while scanning some dense codes like pdf417 commonly found on the back of US and Canadian drivers license cards. I believe this difference caused the analysis image to be skewed making it difficult for MLKit to correctly read the code. Applying this change fixed the issue in my test case.

Note: iOS currently reads pdf417 codes fine as currently configured.

Note: this PR is based on #55 and #60 . Those need to be merged before this one.