### PR TITLE
Error handling on missing permissions

### DIFF
--- a/fast_barcode_scanner/android/build.gradle
+++ b/fast_barcode_scanner/android/build.gradle
@@ -54,7 +54,7 @@ android {
         testImplementation 'org.mockito:mockito-core:5.0.0'
 
         def camerax_version = "1.4.0-alpha05"
-        def mlkit_version = "18.3.0"
+        def mlkit_version = "17.2.0"
         implementation "androidx.camera:camera-camera2:$camerax_version"
         implementation "androidx.camera:camera-lifecycle:$camerax_version"
         implementation "com.google.mlkit:barcode-scanning:$mlkit_version"

--- a/fast_barcode_scanner/android/src/main/AndroidManifest.xml
+++ b/fast_barcode_scanner/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.jhoogstraat.fast_barcode_scanner">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-feature android:name="android.hardware.camera.any" />
     <uses-permission android:name="android.permission.CAMERA"/>
 </manifest>

--- a/fast_barcode_scanner/android/src/main/kotlin/com/jhoogstraat/fast_barcode_scanner/FastBarcodeScannerPlugin.kt
+++ b/fast_barcode_scanner/android/src/main/kotlin/com/jhoogstraat/fast_barcode_scanner/FastBarcodeScannerPlugin.kt
@@ -18,6 +18,7 @@ import com.google.mlkit.vision.barcode.BarcodeScanning
 import com.google.mlkit.vision.common.InputImage
 import com.jhoogstraat.fast_barcode_scanner.types.PreviewConfiguration
 import com.jhoogstraat.fast_barcode_scanner.types.ScannerException
+import com.jhoogstraat.fast_barcode_scanner.types.asFlutterResult
 import com.jhoogstraat.fast_barcode_scanner.types.barcodeStringMap
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
@@ -107,7 +108,7 @@ class FastBarcodeScannerPlugin : FlutterPlugin, MethodCallHandler, StreamHandler
                 "init" -> {
                     initialize(call.arguments as HashMap<String, Any>)
                         .addOnSuccessListener { result.success(it.toMap()) }
-                        .addOnFailureListener { throw it }
+                        .addOnFailureListener { it.asFlutterResult(result) }
                     return
                 }
                 "scan" -> {
@@ -116,7 +117,7 @@ class FastBarcodeScannerPlugin : FlutterPlugin, MethodCallHandler, StreamHandler
                             result.success(barcodes?.map { encode(listOf(it)) })
                         }
                         .addOnFailureListener {
-                            throw ScannerException.AnalysisFailed(it)
+                            ScannerException.AnalysisFailed(it).asFlutterResult(result)
                         }
                     return
                 }

--- a/fast_barcode_scanner/android/src/main/kotlin/com/jhoogstraat/fast_barcode_scanner/types/ScannerException.kt
+++ b/fast_barcode_scanner/android/src/main/kotlin/com/jhoogstraat/fast_barcode_scanner/types/ScannerException.kt
@@ -3,6 +3,14 @@ package com.jhoogstraat.fast_barcode_scanner.types
 import io.flutter.plugin.common.MethodChannel.Result
 import java.io.IOException
 
+fun Exception.asFlutterResult(result: Result) {
+    if (this is ScannerException) {
+        throwFlutterError(result)
+    } else {
+        ScannerException.Unknown(this).throwFlutterError(result)
+    }
+}
+
 sealed class ScannerException : Exception() {
     class NotInitialized : ScannerException()
     class AlreadyInitialized : ScannerException()

--- a/fast_barcode_scanner/example/android/gradle.properties
+++ b/fast_barcode_scanner/example/android/gradle.properties
@@ -1,3 +1,6 @@
 org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/fast_barcode_scanner/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/fast_barcode_scanner/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip

--- a/fast_barcode_scanner/example/android/settings.gradle
+++ b/fast_barcode_scanner/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
+    id "com.android.application" version '8.3.2' apply false
     id "org.jetbrains.kotlin.android" version "1.7.10" apply false
 }
 

--- a/fast_barcode_scanner/pubspec.yaml
+++ b/fast_barcode_scanner/pubspec.yaml
@@ -13,8 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  fast_barcode_scanner_platform_interface:
-    path: ../fast_barcode_scanner_platform_interface
+  fast_barcode_scanner_platform_interface: ^2.0.0-dev.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
When permissions were not granted for the camera the app would completely crash.
Instead of throwing the exception it should be returned to flutter.

also: For some reason I had to upgrade AGP to compile, and change the mlkit version. (the latest bundled version is 17.x afaik).